### PR TITLE
3-1-3-author-book excercise: added correct exception handling for testing of duplicate book ISBN

### DIFF
--- a/3-0-jpa-and-hibernate/3-1-3-author-book/src/test/java/com/bobocode/AuthorBookMappingTest.java
+++ b/3-0-jpa-and-hibernate/3-1-3-author-book/src/test/java/com/bobocode/AuthorBookMappingTest.java
@@ -5,6 +5,7 @@ import com.bobocode.model.Book;
 import com.bobocode.util.EntityManagerUtil;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hibernate.Session;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.*;
 
 import jakarta.persistence.*;
@@ -15,6 +16,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -66,8 +68,8 @@ class AuthorBookMappingTest {
         Book bookWithDuplicateIsbn = createRandomBook();
         bookWithDuplicateIsbn.setIsbn(book.getIsbn());
 
-        assertThatExceptionOfType(RollbackException.class).isThrownBy(() ->
-                emUtil.performWithinTx(entityManager -> entityManager.persist(bookWithDuplicateIsbn)));
+        assertThatThrownBy(() -> emUtil.performWithinTx(entityManager -> entityManager.persist(bookWithDuplicateIsbn)))
+                .isInstanceOfAny(RollbackException.class, ConstraintViolationException.class);
     }
 
     @Test


### PR DESCRIPTION
In task **3-1-3-author-book** it's not clearly mentioned that the `Book` entity should have `@GeneratedValue` annotation with default (`AUTO`) strategy. Also, there are no tests (`AuthorBookMappingTest.java`) where this strategy is checked.

The third test (`saveBookWithDuplicateIsbn()`) will work just fine if `Book` ID generation strategy is default (`AUTO`), but it won't pass the test if `Book` ID generation strategy value is `IDENTITY`. Furthermore, it's really unobvious why the test is failing, but `ConstraintViolationException` will be always there:
1. In case when `Book` ID generation strategy is the default (`AUTO`), hibernate will throw `RollbackException`, but its cause will be `ConstraintViolationException`.
2. In case the `Book` ID generation strategy is `IDENTITY`, hibernate will throw `ConstraintViolationException`.

From my point of view third test `saveBookWithDuplicateIsbn()` should check if any exception mentioned above is the exception thrown by `entityManager.persist(...)` method.