### PR TITLE
3-2-2-photo-comment-dao exercise: fixed test method duplicate display name

### DIFF
--- a/3-0-jpa-and-hibernate/3-2-2-photo-comment-dao/src/test/java/com/bobocode/PhotoCommentMappingTest.java
+++ b/3-0-jpa-and-hibernate/3-2-2-photo-comment-dao/src/test/java/com/bobocode/PhotoCommentMappingTest.java
@@ -234,7 +234,7 @@ class PhotoCommentMappingTest {
 
     @Test
     @Order(16)
-    @DisplayName("Add a new comment")
+    @DisplayName("Add new comments")
     void addNewComments() {
         Photo photo = createRandomPhoto();
         emUtil.performWithinTx(entityManager -> entityManager.persist(photo));


### PR DESCRIPTION
`PhotoCommentMappingTest.java` class has duplicated test method `@DisplayName` text:
1. Method with order number 14 (`saveNewComments()`), and this one is the correct one.
2. Method with order number 16 (`addNewComments()`), this one is the wrong one and fixed by this PR.